### PR TITLE
[PR1] Added An Extra Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ These parameters are slightly different from the kaggle api, but [the kaggle api
 - `kernel_type`: Default value is `script`. The type of kernel. Valid options are `script` and `notebook`.
 - `enable_gpu`: Default value is `enable`. Whether or not the kernel should run on a GPU. `enable` to run on the GPU, otherwise not.
 - `enable_internet`: Default value is `enable`. Whether or not the kernel should be able to access the internet. `enable` to use the internet, otherwise not.
+- `machine_shape`: The accelerator to be added to the kernel to train it (`"NvidiaTeslaT4"` is a verified input to this argument) ⚠️ DO CHECK THIS ⚠️
+
+Possible values as per 
 
 ## Known Issues
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: kaggle action
+name: coder-x15 kaggle action
 author: Rowe Wilson Frederisk Holme
 description: Use kaggle to implement simple CI, which supports GPU.
 

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,9 @@ inputs:
   #   description: A list of competition sources
   # kernel_sources:
   #   description: A list of kernel sources
+  machine_shape:
+    description: The type of accelerator being used with the kernel. Supported ones- 'default' (probable), 'NvidiaTeslaT4' (confirmed), 'NvidiaTeslaT4Highmem' (probable), 'Kaggle_TPU_v3_8' (probable) or 'Kaggle_Nvidia_Tesla_P100' (probable) 
+    default: default
 
 outputs:
   automatic_releases_tag:
@@ -90,6 +93,7 @@ runs:
         $metadata['kernel_type'] = '${{ inputs.kernel_type }}';
         $metadata['enable_gpu'] = '${{ inputs.enable_gpu }}' -eq 'enable';
         $metadata['enable_internet'] = '${{ inputs.enable_internet }}' -eq 'enable';
+        $metadata['machine_shape'] = '${{ inputs.machine_shape }}';
 
         ConvertTo-Json -InputObject $metadata | Set-Content -Path $jsonPath | Out-Null;
 

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
   # kernel_sources:
   #   description: A list of kernel sources
   machine_shape:
-    description: The type of accelerator being used with the kernel. Supported ones- 'default' (probable), 'NvidiaTeslaT4' (confirmed), 'NvidiaTeslaT4Highmem' (probable), 'Kaggle_TPU_v3_8' (probable) or 'Kaggle_Nvidia_Tesla_P100' (probable) 
+    description: The type of accelerator being used with the kernel. Supported ones- 'default' (probable), 'NvidiaTeslaT4' for the 2X T4 runtime (confirmed), 'Kaggle_TPU_v3_8' (probable) or 'Gpu' for the P100 (probable) 
     default: default
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: kaggle Action
+name: kaggle action
 author: Rowe Wilson Frederisk Holme
 description: Use kaggle to implement simple CI, which supports GPU.
 


### PR DESCRIPTION
I found it in a `metadata.json` file I got while pulling my Kaggle Kernel using CLI locally:
```json
{
  "id": "USERNAME/KERNEL_NAME",
  "id_no": <id_no>,
  "title": "Title",
  "code_file": "kernel.ipynb",
  "language": "python",
  "kernel_type": "notebook",
  "is_private": true,
  "enable_gpu": true,
  "enable_tpu": false,
  "enable_internet": true,
  "keywords": [
    "gpu"
  ],
  "dataset_sources": [],
  "kernel_sources": [],
  "competition_sources": [
    "gemma-4-good-hackathon"
  ],
  "model_sources": [],
  "docker_image": "<something>",
  "machine_shape": "NvidiaTeslaT4"
}
```
I've added this to the `action.yml` file, @Frederisk .