### PR TITLE
Allow 'true' or 'enable' for GPU/internet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ For free users, kaggle will provide more than 30 hours of GPU usage per week, wh
 
 These parameters are slightly different from the kaggle api, but [the kaggle api's docs](https://github.com/Kaggle/kaggle-api/wiki/Kernel-Metadata) may still be informative.
 
-- `username`: Required. Your kaggle username.
-- `key`: Required. Your kaggle key/token.
+- `username`: Your kaggle username.
+- `key`: Your kaggle key/token.
 - `title`: Required. The title of the kernel. Please be aware that kernel titles and slugs are linked to each other. A kernel slug is always the title lowercased with dashes (`-`) Replacing spaces.
 - `code_file`: Required. The path to your kernel source code.
 - `language`: Default value is `python`. The language your kernel is written in. Valid options are `python`, `r`, and `rmarkdown`.
 - `kernel_type`: Default value is `script`. The type of kernel. Valid options are `script` and `notebook`.
-- `enable_gpu`: Default value is `enable`. Whether or not the kernel should run on a GPU. `enable` to run on the GPU, otherwise not.
-- `enable_internet`: Default value is `enable`. Whether or not the kernel should be able to access the internet. `enable` to use the internet, otherwise not.
+- `enable_gpu`: Default value is `true`. Whether or not the kernel should run on a GPU. `true` or `enable` to run on the GPU, otherwise not.
+- `enable_internet`: Default value is `true`. Whether or not the kernel should be able to access the internet. `true` or `enable` to use the internet, otherwise not.
 
 ## Known Issues
 

--- a/action.yml
+++ b/action.yml
@@ -5,11 +5,8 @@ description: Use kaggle to implement simple CI, which supports GPU.
 inputs:
   username:
     description: kaggle username
-    required: true
   key:
     description: kaggle key
-    required: true
-
   # id:
   #   description: The URL slug of your kernel
   # id_no:
@@ -30,10 +27,10 @@ inputs:
   #   description: Whether or not the kernel should be private
   enable_gpu:
     description: Whether or not the kernel should run on a GPU
-    default: enable
+    default: 'true'
   enable_internet:
     description: Whether or not the kernel should be able to access the internet
-    default: enable
+    default: 'true'
   # dataset_sources:
   #   description: A list of dataset sources
   # competition_sources:
@@ -88,8 +85,8 @@ runs:
         $metadata['code_file'] = '${{ github.workspace }}' + '/' + '${{ inputs.code_file }}';
         $metadata['language'] = '${{ inputs.language }}';
         $metadata['kernel_type'] = '${{ inputs.kernel_type }}';
-        $metadata['enable_gpu'] = '${{ inputs.enable_gpu }}' -eq 'enable';
-        $metadata['enable_internet'] = '${{ inputs.enable_internet }}' -eq 'enable';
+        $metadata['enable_gpu'] = '${{ inputs.enable_gpu }}' -in 'true', 'enable';
+        $metadata['enable_internet'] = '${{ inputs.enable_internet }}' -in 'true', 'enable';
 
         ConvertTo-Json -InputObject $metadata | Set-Content -Path $jsonPath | Out-Null;
 


### PR DESCRIPTION
Allows certain parameters to be enabled with `true` or `enable`, and changes the default from `enable` to `true` to match the API.